### PR TITLE
added secondary check on ieHr

### DIFF
--- a/R/discharge_events.R
+++ b/R/discharge_events.R
@@ -3,17 +3,17 @@
 #' @description
 #' Discharge event determination - calculates event start and end times based on discharge record.
 #'
-#' @details When a discharge measurement is above qthresh, the algorthim decides whether it belongs to a 
+#' @details When a discharge measurement is above \code{qthresh}, the algorthim decides whether it belongs to a 
 #' "new" event by looking backwards at the last measurement above qthresh. If the difference in time 
-#' is greater than ieHr, then a new event begins. The start and end times of each event, 
+#' is greater than \code{ieHr}, then a new event begins. The start and end times of each event, 
 #' however, are adjusted to the previous or next timestamp, respectively, to account for the "tails" of
 #' the event. The consequence of adjusting the start and end times, however, is that depending on the frequency 
-#' of discharge observations, two observations above qthresh that are greater than ieHr apart (and therefore in seperate events)
-#' can have start and end times that are closer together than ieHr. If ieHr_check = TRUE (default), the algorithm makes a
+#' of discharge observations, two observations above \code{qthresh} that are greater than ieHr apart (and therefore in seperate events)
+#' can have start and end times that are closer together than \code{ieHr}. If \code{ieHr_check = TRUE} (default), the algorithm makes a
 #' final pass through the events dataset and checks for any events that are closer in time than ieHr. If so, 
-#' it will combine those events. If ieHr_check = FALSE, the algorithm will leave the events as-is, and depending 
-#' on discharge measurement frequency and ieHr, you may see events that are closer together than ieHr. In most use-cases, 
-#' ieHr_check = TRUE is appropriate. However, if discharge measurements are infrequent, and the adjustment to the start 
+#' it will combine those events. If \code{ieHr_check = FALSE}, the algorithm will leave the events as-is, and depending 
+#' on discharge measurement frequency and \code{ieHr}, you may see events that are closer together than ieHr. In most use-cases, 
+#' \code{ieHr_check = TRUE} is appropriate. However, if discharge measurements are infrequent, and the adjustment to the start 
 #' and end times are significant, the user may not want the secondary filter on the events. 
 #' 
 #' @param df dataframe that contains discharge and timestamps

--- a/R/discharge_events.R
+++ b/R/discharge_events.R
@@ -131,6 +131,7 @@ discharge_events <- function(df, ieHr=6, qthresh, discharge="Value", time="pdate
                 EndDate = max(EndDate)) %>%
       select(-event_check)
   }
+  out <- as.data.frame(out)
   return(out)
 }
   

--- a/R/discharge_events.R
+++ b/R/discharge_events.R
@@ -1,19 +1,36 @@
-#' discharge_events
+#' Calculate events from discharge record
 #' 
 #' @description
 #' Discharge event determination - calculates event start and end times based on discharge record.
 #'
+#' @details When a discharge measurement is above qthresh, the algorthim decides whether it belongs to a 
+#' "new" event by looking backwards at the last measurement above qthresh. If the difference in time 
+#' is greater than ieHr, then a new event begins. The start and end times of each event, 
+#' however, are adjusted to the previous or next timestamp, respectively, to account for the "tails" of
+#' the event. The consequence of adjusting the start and end times, however, is that depending on the frequency 
+#' of discharge observations, two observations above qthresh that are greater than ieHr apart (and therefore in seperate events)
+#' can have start and end times that are closer together than ieHr. If ieHr_check = TRUE (default), the algorithm makes a
+#' final pass through the events dataset and checks for any events that are closer in time than ieHr. If so, 
+#' it will combine those events. If ieHr_check = FALSE, the algorithm will leave the events as-is, and depending 
+#' on discharge measurement frequency and ieHr, you may see events that are closer together than ieHr. In most use-cases, 
+#' ieHr_check = TRUE is appropriate. However, if discharge measurements are infrequent, and the adjustment to the start 
+#' and end times are significant, the user may not want the secondary filter on the events. 
+#' 
 #' @param df dataframe that contains discharge and timestamps
 #' @param qthresh numeric, Discharge threshold value, over which an event is considered to be occuring.
 #' @param ieHr numeric, Interevent period in hours, defaults to 6. 
 #' The amount of time between discharge measurements above threshold required to be considered a new event.
 #' @param discharge string, Column name where discharge values are stored. Defaults to "Value".
-#' @param time string, column name where dates are stored as POSIXct values, defaults to "pdate"
+#' @param time string, column name where dates are stored as POSIXct values, defaults to "pdate".
+#' @param ieHr_check logical, whether to check the calculated events data frame for events that are closer
+#' together than ieHr. This can happen due to the start and end time corrections for the "tails" of the event. 
+#' If TRUE, events closer than ieHr apart will be combined. If FALSE, events will be left as-is. 
+#' See the details section below for more information. 
 #' @return dataframe of all discharge events based on ieHr and qthresh criteria. Includes start and end times for each event. 
 #' @import dplyr
 #' @importFrom rlang sym
 #' @export
-discharge_events <- function(df,ieHr=6,qthresh,discharge="Value",time="pdate"){
+discharge_events <- function(df, ieHr=6, qthresh, discharge="Value", time="pdate", ieHr_check = TRUE){
   
   if(!time %in% names(df)){
     stop("Supplied 'time' column name not in df")
@@ -93,6 +110,26 @@ discharge_events <- function(df,ieHr=6,qthresh,discharge="Value",time="pdate"){
   out <- data.frame(stormnum = start.dates$event,
                        StartDate = start.dates.adjusted[[time]],
                        EndDate = end.dates.adjusted[[time]])
+  
+  if (isTRUE(ieHr_check)) {
+    event_diff <- difftime(out$StartDate[2:nrow(out)], out$EndDate[1:(nrow(out)-1)], units = 'mins')
+    out$event_check <- NA
+    out$event_check[1] <- 1
+    
+    # loop that assigns new event column
+    for (i in 2:nrow(out)){
+      if (event_diff[i-1] >= ieMin) {
+        out$event_check[i] <- out$event_check[i-1] + 1
+      } else {
+        out$event_check[i] <- out$event_check[i-1]
+      }
+    }
+    
+    out <- group_by(out, event_check) %>%
+      summarize(stormnum = first(event_check),
+                StartDate = min(StartDate), 
+                EndDate = max(EndDate))
+  }
   return(out)
 }
   

--- a/R/discharge_events.R
+++ b/R/discharge_events.R
@@ -128,7 +128,8 @@ discharge_events <- function(df, ieHr=6, qthresh, discharge="Value", time="pdate
     out <- group_by(out, event_check) %>%
       summarize(stormnum = first(event_check),
                 StartDate = min(StartDate), 
-                EndDate = max(EndDate))
+                EndDate = max(EndDate)) %>%
+      select(-event_check)
   }
   return(out)
 }

--- a/man/discharge_events.Rd
+++ b/man/discharge_events.Rd
@@ -2,26 +2,45 @@
 % Please edit documentation in R/discharge_events.R
 \name{discharge_events}
 \alias{discharge_events}
-\title{discharge_events}
+\title{Calculate events from discharge record}
 \usage{
 discharge_events(df, ieHr = 6, qthresh, discharge = "Value",
-  time = "pdate")
+  time = "pdate", ieHr_check = TRUE)
 }
 \arguments{
-\item{df}{dataframe with discharge}
+\item{df}{dataframe that contains discharge and timestamps}
 
-\item{ieHr}{numeric Interevent period in hours, defaults to 6. 
+\item{ieHr}{numeric, Interevent period in hours, defaults to 6. 
 The amount of time between discharge measurements above threshold required to be considered a new event.}
 
-\item{qthresh}{numeric Discharge threshold value, over which an event is considered to be occuring.}
+\item{qthresh}{numeric, Discharge threshold value, over which an event is considered to be occuring.}
 
-\item{discharge}{string Column name where discharge values are stored. Defaults to "Value".}
+\item{discharge}{string, Column name where discharge values are stored. Defaults to "Value".}
 
-\item{time}{string column name where dates are stored as POSIXct values, defaults to "pdate"}
+\item{time}{string, column name where dates are stored as POSIXct values, defaults to "pdate".}
+
+\item{ieHr_check}{logical, whether to check the calculated events data frame for events that are closer
+together than ieHr. This can happen due to the start and end time corrections for the "tails" of the event. 
+If TRUE, events closer than ieHr apart will be combined. If FALSE, events will be left as-is. 
+See the details section below for more information.}
 }
 \value{
 dataframe of all discharge events based on ieHr and qthresh criteria. Includes start and end times for each event.
 }
 \description{
 Discharge event determination - calculates event start and end times based on discharge record.
+}
+\details{
+When a discharge measurement is above qthresh, the algorthim decides whether it belongs to a 
+"new" event by looking backwards at the last measurement above qthresh. If the difference in time 
+is greater than ieHr, then a new event begins. The start and end times of each event, 
+however, are adjusted to the previous or next timestamp, respectively, to account for the "tails" of
+the event. The consequence of adjusting the start and end times, however, is that depending on the frequency 
+of discharge observations, two observations above qthresh that are greater than ieHr apart (and therefore in seperate events)
+can have start and end times that are closer together than ieHr. If ieHr_check = TRUE (default), the algorithm makes a
+final pass through the events dataset and checks for any events that are closer in time than ieHr. If so, 
+it will combine those events. If ieHr_check = FALSE, the algorithm will leave the events as-is, and depending 
+on discharge measurement frequency and ieHr, you may see events that are closer together than ieHr. In most use-cases, 
+ieHr_check = TRUE is appropriate. However, if discharge measurements are infrequent, and the adjustment to the start 
+and end times are significant, the user may not want the secondary filter on the events.
 }

--- a/man/discharge_events.Rd
+++ b/man/discharge_events.Rd
@@ -31,16 +31,16 @@ dataframe of all discharge events based on ieHr and qthresh criteria. Includes s
 Discharge event determination - calculates event start and end times based on discharge record.
 }
 \details{
-When a discharge measurement is above qthresh, the algorthim decides whether it belongs to a 
+When a discharge measurement is above \code{qthresh}, the algorthim decides whether it belongs to a 
 "new" event by looking backwards at the last measurement above qthresh. If the difference in time 
-is greater than ieHr, then a new event begins. The start and end times of each event, 
+is greater than \code{ieHr}, then a new event begins. The start and end times of each event, 
 however, are adjusted to the previous or next timestamp, respectively, to account for the "tails" of
 the event. The consequence of adjusting the start and end times, however, is that depending on the frequency 
-of discharge observations, two observations above qthresh that are greater than ieHr apart (and therefore in seperate events)
-can have start and end times that are closer together than ieHr. If ieHr_check = TRUE (default), the algorithm makes a
+of discharge observations, two observations above \code{qthresh} that are greater than ieHr apart (and therefore in seperate events)
+can have start and end times that are closer together than \code{ieHr}. If \code{ieHr_check = TRUE} (default), the algorithm makes a
 final pass through the events dataset and checks for any events that are closer in time than ieHr. If so, 
-it will combine those events. If ieHr_check = FALSE, the algorithm will leave the events as-is, and depending 
-on discharge measurement frequency and ieHr, you may see events that are closer together than ieHr. In most use-cases, 
-ieHr_check = TRUE is appropriate. However, if discharge measurements are infrequent, and the adjustment to the start 
+it will combine those events. If \code{ieHr_check = FALSE}, the algorithm will leave the events as-is, and depending 
+on discharge measurement frequency and \code{ieHr}, you may see events that are closer together than ieHr. In most use-cases, 
+\code{ieHr_check = TRUE} is appropriate. However, if discharge measurements are infrequent, and the adjustment to the start 
 and end times are significant, the user may not want the secondary filter on the events.
 }


### PR DESCRIPTION
Mari noticed issue that if ieHr is small enough, and the discharge measurements are infrequent enough, that there are cases when correcting back and forward a step to adjust start and end times for discharge events outputs events that are less than ieHr apart. Now there is an argument (ieHr_check) that users can specify. If ieHr_check = TRUE, then the algorithm will check the event list output to see if there are any of these cases, and combine events that are less than ieHr apart. We let the user control this because we thought there might in instances where discharge measurements are too far apart, and you don't want the correction made. 