### PR TITLE
fixed discharge_events to handle discharge record with mid-event start or end

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,3 +24,4 @@ Depends:
 LazyLoad: yes
 LazyData: yes
 RoxygenNote: 6.0.1
+Suggests: testthat

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(Rainmaker)
+
+test_check("Rainmaker")

--- a/tests/testthat/test_discharge_events.R
+++ b/tests/testthat/test_discharge_events.R
@@ -1,0 +1,3 @@
+# tests the function discharge_events
+
+# test discharge record that starts and ends in mid-storm


### PR DESCRIPTION
Now throws warning + NA values when discharge record starts or ends mid-event. 