### PR TITLE
Check for issues when RMprep runs

### DIFF
--- a/R/RMprep.R
+++ b/R/RMprep.R
@@ -84,10 +84,16 @@ RMprep <- function(df,
                      df[,dates.in[1]]," ",
                      hour,":",minute,sep="")
     }
-    if(tz=="") pdate <-  as.POSIXct(dates,format=Date.style[date.type])
-    else pdate <-  as.POSIXct(dates,format=Date.style[date.type],tz=tz)
-    df$pdate <- pdate
-    names(df)[ncol(df)] <- dates.out
+    if(tz=="") {
+      warning("No time zone specified. Function will use system time zone (e.g., sys.timezone()).")
+      pdate <-  as.POSIXct(dates,format=Date.style[date.type])
+    } else {
+      pdate <-  as.POSIXct(dates,format=Date.style[date.type],tz=tz)
+    }
+    if (any(is.na(pdate))) {
+      warning(paste0("NA values present in column ", date.out, '. Please check whether input data contains NA values and that the proper time zone was specified.'))
+    }
+    df[date.out] <- pdate
   }
   
   # Change column headers as specified

--- a/R/RMprep.R
+++ b/R/RMprep.R
@@ -91,7 +91,7 @@ RMprep <- function(df,
       pdate <-  as.POSIXct(dates,format=Date.style[date.type],tz=tz)
     }
     if (any(is.na(pdate))) {
-      warning(paste0("NA values present in column ", date.out, '. Please check whether input data contains NA values and that the proper time zone was specified.'))
+      warning(paste0("NA values present in column ", date.out, '. Please check whether input data contain NA values and/or that the proper time zone was specified.'))
     }
     df[date.out] <- pdate
   }


### PR DESCRIPTION
Currently, if no timezone is specified, RMprep uses computer time zone, which means it can silently produce NA values in dates if the computer time zone is different from the data time zone. Now, it will throw a warning if tz is not specified, but also checks for NA values in pdate before exporting. Will still run, just throws warning. 