### PR TITLE
Update to RMevents_sample date handling

### DIFF
--- a/R/RMevents_sample.R
+++ b/R/RMevents_sample.R
@@ -112,8 +112,12 @@ RMevents_sample <- function(df,
       }
       tipsbystorm <- sub_tips
     } else {
-      startRainDates <- as.POSIXct(c(startRainDates,BD), origin = "1970-01-01", tz = rain_timezone)
-      endRainDates <- as.POSIXct(c(endRainDates,ED), origin = "1970-01-01", tz = rain_timezone)
+      #startRainDates <- as.POSIXct(c(startRainDates,BD), origin = "1970-01-01", tz = rain_timezone)
+      #endRainDates <- as.POSIXct(c(endRainDates,ED), origin = "1970-01-01", tz = rain_timezone)
+      startRainDates <- c(startRainDates,BD)
+      endRainDates <- c(endRainDates,ED)
+      
+      
       if (nrow(sub_tips) > 0) {
         event <- event + 1
       } else {
@@ -127,8 +131,8 @@ RMevents_sample <- function(df,
     }
   }
   
-  dfsamples$StartDate <- startRainDates
-  dfsamples$EndDate <- endRainDates
+  dfsamples$StartDate <- as.POSIXct(startRainDates, origin = '1970-01-01', tz = rain_timezone)
+  dfsamples$EndDate <- as.POSIXct(endRainDates, origin = '1970-01-01', tz = rain_timezone)
   dfsamples$rain <- rainDepth
   dfsamples$stormnum <- 1:nrow(dfsamples)
   

--- a/tests/testthat/test_discharge_events.R
+++ b/tests/testthat/test_discharge_events.R
@@ -1,3 +1,5 @@
 # tests the function discharge_events
 
 # test discharge record that starts and ends in mid-storm
+
+# test time zones


### PR DESCRIPTION
Dates were still buggy.

Had to move the tz conversion outside of the loop for some reason. Not exactly sure why this works, but suspect there was another place within the loop (perhaps down a different `if` route) where dates were being converted to computer time. So, now that it's being done in the final step outside of the loop, dates seem to be preserved.